### PR TITLE
fix AssertionError on empty catalog

### DIFF
--- a/mbcat/catalog.py
+++ b/mbcat/catalog.py
@@ -131,13 +131,14 @@ class Catalog(object):
         fileList = os.listdir(self.rootPath)
 
         widgets = ["Releases: ", progressbar.Bar(marker="=", left="[", right="]"), " ", progressbar.Fraction(), " ", progressbar.Percentage() ]
-        pbar = progressbar.ProgressBar(widgets=widgets, maxval=len(fileList)).start()
+        if len(fileList) > 0:
+            pbar = progressbar.ProgressBar(widgets=widgets, maxval=len(fileList)).start()
 
-        for releaseId in fileList:
-            if len(releaseId) == 36:
-                pbar.increment()
-                yield releaseId
-        pbar.finish()
+            for releaseId in fileList:
+                if len(releaseId) == 36:
+                    pbar.increment()
+                    yield releaseId
+            pbar.finish()
 
     def loadExtraData(self, releaseId):
         # load extra data


### PR DESCRIPTION
ProgressBar doesn't like having 0 as limit,
leading to an AssertionError:

```
Traceback (most recent call last):
  File "catalog-cli.py", line 280, in <module>
    s = Shell()
  File "catalog-cli.py", line 35, in __init__
    self.c.load()
  File "/home/jonnyjd/git/_musicbrainz/musicbrainz-catalog/mbcat/catalog.py", line 171, in load
    for releaseId in self.loadReleaseIds():
  File "/home/jonnyjd/git/_musicbrainz/musicbrainz-catalog/mbcat/catalog.py", line 134, in loadReleaseIds
    pbar = progressbar.ProgressBar(widgets=widgets, maxval=len(fileList)).start()
  File "/home/jonnyjd/git/_musicbrainz/musicbrainz-catalog/progressbar.py", line 261, in __init__
    assert maxval > 0
AssertionError
```

Empty catalog does mean having an empty `release-id` directory. Putting any file (even an empty `blub.txt`) in this directory also prevents this error.
Starting users won't have any file in this folder.
